### PR TITLE
fix: 위키 페이지 기능 및 반응형 수정

### DIFF
--- a/components/wiki/wikiHeader/index.tsx
+++ b/components/wiki/wikiHeader/index.tsx
@@ -99,21 +99,23 @@ const WikiHeader = ({
             <span className={styles['user-name']}>{profile.name}</span>
             {profile.content &&
               (showParticipateBtn ? (
-                <Button
-                  className={styles['participate-btn']}
-                  color="primary"
-                  size="large"
-                  onClick={() => {
-                    checkParticipationStatus();
-                    onParticipateClick();
-                  }}
-                >
-                  위키 참여하기
-                </Button>
+                <>
+                  <Button
+                    className={styles['participate-btn']}
+                    color="primary"
+                    size="large"
+                    onClick={() => {
+                      checkParticipationStatus();
+                      onParticipateClick();
+                    }}
+                  >
+                    위키 참여하기
+                  </Button>
+                </>
               ) : (
                 <>
                   <Button
-                    className={styles['Editing-btn']}
+                    className={styles['editing-btn']}
                     color="disabled"
                     size="large"
                     onClick={onParticipateClick}

--- a/components/wiki/wikiHeader/index.tsx
+++ b/components/wiki/wikiHeader/index.tsx
@@ -31,7 +31,10 @@ const WikiHeader = ({
     'success',
   );
   const [showSnackBar, setShowSnackBar] = useState<boolean>(false);
-  const [showLinkCopyModal, setShowLinkCopyModal] = useState<boolean>(false);
+  const [showLinkCopySnackBar, setShowLinkCopySnackBar] =
+    useState<boolean>(false);
+  const [showEditingSnackBar, setShowEditingSnackBar] =
+    useState<boolean>(false);
 
   const handleCopyClick = () => {
     const linkToCopy = `https://www.wikied.kr/${profile.code}`;
@@ -41,13 +44,13 @@ const WikiHeader = ({
         setSnackBarMessage('내 위키 링크가 복사되었습니다.');
         setSnackBarType('success');
         setShowSnackBar(true);
-        setShowLinkCopyModal(true);
+        setShowLinkCopySnackBar(true);
       })
       .catch(() => {
         setSnackBarMessage('복사에 실패했습니다.');
         setSnackBarType('error');
         setShowSnackBar(true);
-        setShowLinkCopyModal(true);
+        setShowLinkCopySnackBar(true);
       });
   };
 
@@ -57,13 +60,14 @@ const WikiHeader = ({
     );
     setSnackBarType('error');
     setShowSnackBar(true);
+    setShowEditingSnackBar(true);
   };
 
   useEffect(() => {
     if (showSnackBar) {
       const timer = setTimeout(() => {
         setShowSnackBar(false);
-        setShowLinkCopyModal(false);
+        setShowLinkCopySnackBar(false);
       }, 3000);
 
       return () => clearTimeout(timer);

--- a/components/wiki/wikiHeader/styles.module.scss
+++ b/components/wiki/wikiHeader/styles.module.scss
@@ -19,6 +19,10 @@
       top: 18px;
       left: 30px;
     }
+    .participate-btn,
+    editing-btn {
+      @include Size(160px, '');
+    }
   }
 }
 
@@ -41,7 +45,7 @@
     }
 
     .participate-btn,
-    .Editing-btn {
+    .editing-btn {
       @include Size(160px, '');
       white-space: nowrap;
     }
@@ -60,12 +64,13 @@
       display: flex;
       align-items: center;
       gap: 5px;
+      overflow: hidden;
 
       .link-copy-btn {
         overflow: hidden;
-        white-space: nowrap;
         text-decoration: none;
         text-overflow: ellipsis;
+        place-self: flex-start;
         background-color: transparent;
 
         .link-address {
@@ -124,7 +129,8 @@
         );
       }
 
-      .participate-btn {
+      .participate-btn,
+      .editing-btn {
         @include Size(120px, 43px);
       }
     }

--- a/pages/wiki/[code]/index.tsx
+++ b/pages/wiki/[code]/index.tsx
@@ -177,7 +177,7 @@ const Wiki = (props: WikiProps) => {
         className={clsx(styles['container'], {
           [styles['non-editable']]: !isEditable,
           [styles['non-editable-no-data']]:
-            !isEditable && sectionsData.length === 0,
+            !isEditable && profile.content.length === 0,
           [styles['editable']]: isEditable,
         })}
       >

--- a/pages/wiki/[code]/index.tsx
+++ b/pages/wiki/[code]/index.tsx
@@ -26,7 +26,7 @@ const Wiki = (props: WikiProps) => {
   const [profile, setProfile] = useState<any>(null);
   const [sectionsData, setSectionsData] = useState<Section[]>([]);
   const [isEditable, setIsEditable] = useState<boolean>(false);
-  const [showParticipateBtn, setShowParticipateBtn] = useState<boolean>();
+  const [showParticipateBtn, setShowParticipateBtn] = useState<boolean>(true);
   const [isErrorModalOpen, setIsErrorModalOpen] = useState<boolean>(false);
   const [editTimeout, setEditTimeout] = useState<NodeJS.Timeout | null>(null);
   const [isModalVisible, setModalVisible] = useState(false);
@@ -66,6 +66,7 @@ const Wiki = (props: WikiProps) => {
   const checkEditStatus = useCallback(async (code: string) => {
     try {
       const response = await checkProfileEditStatus(code);
+      console.log('checkProfileEditStatus API Response1:', response);
     } catch (err) {
       console.error(err);
     }
@@ -138,7 +139,7 @@ const Wiki = (props: WikiProps) => {
       if (typeof code === 'string') {
         await getList(code);
         const response = await checkProfileEditStatus(code);
-        console.log('checkProfileEditStatus API Response:', response);
+        console.log('checkProfileEditStatus API Response2:', response);
         if (response.status === 200) {
           setResponseState(true);
           setShowParticipateBtn(true);

--- a/pages/wiki/[code]/styles.module.scss
+++ b/pages/wiki/[code]/styles.module.scss
@@ -14,7 +14,10 @@
     @include Size(100%, '');
     max-width: 1920px;
     display: grid;
-    grid-template-columns: minmax(60px, 1fr) minmax(0, 860px) 80px 320px 200px;
+    grid-template-columns: minmax(60px, 1fr) minmax(0, 860px) 80px 320px minmax(
+        60px,
+        0.43479fr
+      );
     grid-template-rows: 190px auto;
     position: relative;
 
@@ -68,7 +71,10 @@
 
   .wiki-main {
     display: grid;
-    grid-template-columns: minmax(60px, 1fr) minmax(0, 1120px) 120px 400px 80px !important;
+    grid-template-columns: minmax(60px, 1fr) minmax(0, 1120px) 120px 400px minmax(
+        60px,
+        0.4fr
+      ) !important;
     grid-template-areas:
       'space1 header space2 aside space3'
       'space1 article space2 article space3';
@@ -112,7 +118,10 @@
   padding-top: 40px;
 
   .wiki-main {
-    grid-template-columns: minmax(60px, 1fr) minmax(0, 859px) 81px 320px 200px;
+    grid-template-columns: minmax(60px, 1fr) minmax(0, 859px) 81px 320px minmax(
+        60px,
+        0.43479fr
+      );
 
     .space1 {
       height: 16px;


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

이제 처음 들어갔을 때 다 `편집중...` 이라고 뜨는 부분만 해결하면 될 것 같은데, 추가적으로 수정해야 할 부분 있으면 말씀 주세요😊

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ✅ 작업 내용
1. **링크 복사 기능 수정**
    - 다른 사람이 편집중(response.status가 204일 때) 링크 복사 스낵바가 안 뜨는 문제 해결
    <br/>  
2. **초기에 '위키 참여하기' 버튼이 false로 설정되어 잠시 오류 스낵바 뜨는 문제 해결**
    <br/>  
3. **모바일 사이즈 반응형 수정**
    - 주소 표시하는 부분에 `white-space: nowrap` 설정되어 있었는데요.
      이것때문에 모바일 사이즈에서 헤더보다 본문 너비가 넓게 보여서 이 부분 수정했습니다.

## 📸 스크린샷
- **모바일 사이즈 반응형 수정**
   - 기존
      ![image](https://github.com/user-attachments/assets/c44f3c61-51d7-4522-813a-be7790afb042)
   - 변경
      ![image](https://github.com/user-attachments/assets/ec613889-f1d4-499a-aab0-a3d12c0406a7)

## :pushpin: 이슈 사항
- 이건 다른 사람이 편집 중일 때 표시해주는 건 똑같은데, 둘 중 선택해서 하라는 건지 잘 모르겠습니다.
  지금은 상태표시-경고로 구현되어 있습니다.
   ![image](https://github.com/user-attachments/assets/b70a226e-b6fa-40cf-893f-38816786c6c5)
   ![image](https://github.com/user-attachments/assets/21407b60-82ed-4fe1-b138-e9c864679a7e)

## :writing_hand: 궁금한 점
- 
